### PR TITLE
[33기 염종은] ADD: jobDetail page layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   },
   "javascript.format.enable": false,
   "eslint.alwaysShowStatus": true,
-  "files.autoSave": "onFocusChange"
+  "files.autoSave": "onFocusChange",
+  "cSpell.words": ["Naver", "Navermaps"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "33-2nd-react-wantus",
       "version": "0.1.0",
       "dependencies": {
+        "@react-icons/all-files": "^4.1.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -16,8 +17,13 @@
         "react-icons": "^4.4.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
+        "react-multi-carousel": "^2.8.0",
+        "react-naver-maps": "^0.0.13",
+        "react-slick": "^0.29.0",
+        "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.4.1",
+        "swiper": "^8.2.3",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3013,6 +3019,14 @@
         }
       }
     },
+    "node_modules/@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -5275,6 +5289,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw=="
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -5350,6 +5369,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/clean-css": {
       "version": "5.3.0",
@@ -6361,6 +6385,14 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -6501,6 +6533,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
@@ -6512,6 +6552,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -7582,6 +7627,34 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fbjs": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+      "dependencies": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
+      }
+    },
+    "node_modules/fbjs/node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js."
+    },
+    "node_modules/fbjs/node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8193,6 +8266,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -8676,6 +8754,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -8990,6 +9076,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11045,6 +11140,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11137,6 +11238,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -11250,6 +11359,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/load-js/-/load-js-3.0.3.tgz",
+      "integrity": "sha512-y1Iqt5vikLPrI9xJHV3gK6TKDvGdJQPHjejJgP4BmS7wx4oo45+IMvnAT9jY8quL9NGtt0WlTuLq1pw7WuODYA=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -11290,10 +11404,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -11309,6 +11433,11 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -11651,6 +11780,23 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/node-fetch/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/node-forge": {
@@ -13777,6 +13923,91 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-multi-carousel": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.0.tgz",
+      "integrity": "sha512-xuxQVGGiH8yWDDWgt9Z9+C+zzoACuBT740cV+6To52DYCwLlQGJIntDFLOCqMsO85Ist1x+630HA8lazb/a/tA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-naver-maps": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/react-naver-maps/-/react-naver-maps-0.0.13.tgz",
+      "integrity": "sha512-d4tagxVILGTzRaIW+GwFjZ9HhoBoODFy/Ly0ClWZ9neIJ7QCzCw/x0OPmZUYki0Kke6KcngQm6/mhx+mVdh3ug==",
+      "dependencies": {
+        "create-react-context": "^0.2.3",
+        "debug": "^3.1.0",
+        "hoist-non-react-statics": "^3.2.0",
+        "invariant": "^2.2.4",
+        "load-js": "^3.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.difference": "^4.5.0",
+        "prop-types": "^15.6.2",
+        "react-resize-detector": "^2.2.0",
+        "recompose": "^0.26.0",
+        "shallowequal": "^1.1.0",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/react-naver-maps/node_modules/create-react-context": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "dependencies": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-naver-maps/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/react-naver-maps/node_modules/react-resize-detector": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+      "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.6.0",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-naver-maps/node_modules/recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "dependencies": {
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "symbol-observable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-naver-maps/node_modules/recompose/node_modules/hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13879,6 +14110,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -14080,6 +14327,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -14575,6 +14827,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -14638,6 +14895,14 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
       }
     },
     "node_modules/sockjs": {
@@ -14756,6 +15021,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -14819,6 +15089,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -15180,6 +15455,37 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.2.3.tgz",
+      "integrity": "sha512-TTLvWH52732JnQZiCCF8VXRG1HrdOdttpvcxM0kgS46GHvuXle7/1jyPek3DNtl76TUwCcnkOadONcXXEbymFQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -15558,6 +15864,24 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -15748,6 +16072,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -18659,6 +18991,12 @@
         "source-map": "^0.7.3"
       }
     },
+    "@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "requires": {}
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -20347,6 +20685,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw=="
+    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -20401,6 +20744,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "5.3.0",
@@ -21136,6 +21484,14 @@
         "entities": "^2.0.0"
       }
     },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -21236,6 +21592,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "enhanced-resolve": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
@@ -21244,6 +21608,11 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
+    },
+    "enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "entities": {
       "version": "2.2.0",
@@ -22032,6 +22401,35 @@
         "bser": "2.1.1"
       }
     },
+    "fbjs": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -22456,6 +22854,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -22812,6 +23215,14 @@
         "side-channel": "^1.0.4"
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -23012,6 +23423,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -24515,6 +24935,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -24587,6 +25013,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
     },
     "json5": {
       "version": "2.2.1",
@@ -24668,6 +25102,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "load-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/load-js/-/load-js-3.0.3.tgz",
+      "integrity": "sha512-y1Iqt5vikLPrI9xJHV3gK6TKDvGdJQPHjejJgP4BmS7wx4oo45+IMvnAT9jY8quL9NGtt0WlTuLq1pw7WuODYA=="
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -24696,10 +25135,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -24715,6 +25164,11 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -24968,6 +25422,22 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+        }
       }
     },
     "node-forge": {
@@ -26334,6 +26804,79 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-multi-carousel": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.0.tgz",
+      "integrity": "sha512-xuxQVGGiH8yWDDWgt9Z9+C+zzoACuBT740cV+6To52DYCwLlQGJIntDFLOCqMsO85Ist1x+630HA8lazb/a/tA=="
+    },
+    "react-naver-maps": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/react-naver-maps/-/react-naver-maps-0.0.13.tgz",
+      "integrity": "sha512-d4tagxVILGTzRaIW+GwFjZ9HhoBoODFy/Ly0ClWZ9neIJ7QCzCw/x0OPmZUYki0Kke6KcngQm6/mhx+mVdh3ug==",
+      "requires": {
+        "create-react-context": "^0.2.3",
+        "debug": "^3.1.0",
+        "hoist-non-react-statics": "^3.2.0",
+        "invariant": "^2.2.4",
+        "load-js": "^3.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.difference": "^4.5.0",
+        "prop-types": "^15.6.2",
+        "react-resize-detector": "^2.2.0",
+        "recompose": "^0.26.0",
+        "shallowequal": "^1.1.0",
+        "warning": "^4.0.2"
+      },
+      "dependencies": {
+        "create-react-context": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+          "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+          "requires": {
+            "fbjs": "^0.8.0",
+            "gud": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "react-resize-detector": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+          "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+          "requires": {
+            "lodash.debounce": "^4.0.8",
+            "lodash.throttle": "^4.1.1",
+            "prop-types": "^15.6.0",
+            "resize-observer-polyfill": "^1.5.0"
+          }
+        },
+        "recompose": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+          "requires": {
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "symbol-observable": "^1.0.4"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+            }
+          }
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -26409,6 +26952,18 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "readable-stream": {
@@ -26566,6 +27121,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -26915,6 +27475,11 @@
         "send": "0.18.0"
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -26967,6 +27532,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "requires": {}
     },
     "sockjs": {
       "version": "0.3.24",
@@ -27063,6 +27634,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -27107,6 +27683,11 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -27370,6 +27951,20 @@
           }
         }
       }
+    },
+    "swiper": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.2.3.tgz",
+      "integrity": "sha512-TTLvWH52732JnQZiCCF8VXRG1HrdOdttpvcxM0kgS46GHvuXle7/1jyPek3DNtl76TUwCcnkOadONcXXEbymFQ==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -27643,6 +28238,11 @@
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "peer": true
     },
+    "ua-parser-js": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -27787,6 +28387,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "^4.4.0",
+    "react-multi-carousel": "^2.8.0",
+    "react-naver-maps": "^0.0.13",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.29.0",
+    "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.1",
+    "swiper": "^8.2.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/data/followData.json
+++ b/public/data/followData.json
@@ -1,0 +1,1 @@
+{ "message": "FOLLOW_SUCCESS", "results": false, "follow_count": 4 }

--- a/public/data/jobDetailData.json
+++ b/public/data/jobDetailData.json
@@ -1,0 +1,25 @@
+{
+  "job_detail": {
+    "job_id": 1,
+    "job_name": "STO 프론트개발자",
+    "job_content": "<p><span>‘제네시스네스트‘는 2022년 5월에 게임플랫폼 전문가들과 함께 출발을 하였습니다.<br><br>우리의 목표는 게임 개발자가 가장 먼저 떠올리는 글로벌 1위의 게임플랫폼서비스를 구축하는 것입니다. 게임개발자가 컨텐츠 개발에 집중할 수 있도록 컨텐츠 외적인 게임공통서비스, 그리고 P2E를 손쉽게 구현을 할 수 있는 오픈플랫폼을 제공합니다.<br><br>우리는 이미 게임플랫폼과 게임용 블록체인플랫폼을 서비스하고 성공시킨 경험을 가진 훌륭한 프로의식, 인격, 열정을 갖춘 전문가들로 구성되어 있습니다.<br><br>‘제네시스네스트’와 함께 성장하고 상상을 게임플랫폼의 비전을 함께할 당신을 기다리고 있습니다!</span></p>",
+    "job_deadline": "2022-06-30",
+    "company_id": 1,
+    "company_name": "위코드",
+    "company_address": "서울특별시 마포구 독막로 331",
+    "company_location": "서울",
+    "company_logo": "https://i.pinimg.com/564x/f6/16/1d/f6161d61d9223223fcad406a632fa828.jpg",
+    "company_images": [
+      "https://i.pinimg.com/564x/27/e0/74/27e074008b1d54fb474224de9102651b.jpg",
+      "https://i.pinimg.com/564x/db/e6/14/dbe61467598a34dc1b363374526dcad8.jpg",
+      "https://i.pinimg.com/564x/52/6e/14/526e144d98cede550d3500578bda8211.jpg"
+    ],
+    "company_latitude": "37.50644",
+    "company_longitude": "127.05364"
+  },
+  "user_info": {
+    "id": 17,
+    "name": "황재승",
+    "email": "cmerak@hotmail.com"
+  }
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,6 +3,7 @@ import Signup from './pages/signup/Signup';
 import Login from './pages/login/Login';
 import JobList from './pages/joblist/JobList';
 import JobDetail from './pages/jobdetail/JobDetail';
+import LikePage from './pages/likePage/LikePage';
 import Resume from './pages/resume/Resume';
 import Nav from './components/nav/Nav';
 
@@ -11,10 +12,11 @@ const Router = () => {
     <BrowserRouter>
       <Nav />
       <Routes>
+        <Route path="/likePage" element={<LikePage />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/login" element={<Login />} />
         <Route path="/joblist" element={<JobList />} />
-        <Route path="/jobdetail" element={<JobDetail />} />
+        <Route path="/jobdetail/:company_id" element={<JobDetail />} />
         <Route path="/resume" element={<Resume />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/jobdetail/Apply.js
+++ b/src/pages/jobdetail/Apply.js
@@ -1,0 +1,77 @@
+import styled from 'styled-components';
+import { BsHeartFill } from '@react-icons/all-files/bs/BsHeartFill';
+
+const Apply = ({ setApply, likeBtn, follow }) => {
+  const goToApplyInformation = () => {
+    setApply(false);
+  };
+
+  return (
+    <ApplyArea>
+      <ApplyTitle>지원하기</ApplyTitle>
+      <ApplyDescription>프론트/백엔드 모바일웹 분야 개발자</ApplyDescription>
+      <ApplyBtn bg="white" color="#3366ff" onClick={likeBtn}>
+        좋아요
+      </ApplyBtn>
+      <ApplyBtn bg="#3366ff" color="white" onClick={goToApplyInformation}>
+        지원하기
+      </ApplyBtn>
+      <LikeBox onClick={likeBtn}>
+        <HeartIcon isFollow={follow.results} />
+        <span>{follow.follow_count}</span>
+      </LikeBox>
+    </ApplyArea>
+  );
+};
+
+export default Apply;
+
+const ApplyArea = styled.div`
+  width: 100%;
+  padding: 20px;
+  border: 1px solid #e1e2e3;
+  border-radius: 4px;
+`;
+
+const ApplyTitle = styled.div`
+  margin-bottom: 30px;
+  font-weight: 600;
+`;
+
+const ApplyDescription = styled.div`
+  margin-bottom: 30px;
+  color: #999999;
+`;
+
+const ApplyBtn = styled.button`
+  padding: 15px 40px;
+  width: 350px;
+  border: 1px solid #3366ff;
+  border-radius: 50px;
+  margin-bottom: 10px;
+  background: ${props => props.bg};
+  font-size: 20px;
+  font-weight: 700;
+  color: ${props => props.color};
+  cursor: pointer;
+`;
+const LikeBox = styled.p`
+  display: flex;
+  justify-content: center;
+  width: 60px;
+  margin-top: 20px;
+  padding: 5px 10px;
+  border: 1px solid #e1e2e3;
+  border-radius: 50px;
+  font-size: 16px;
+  color: gray;
+  cursor: pointer;
+
+  span {
+    margin-left: 5px;
+  }
+`;
+
+const HeartIcon = styled(BsHeartFill)`
+  color: ${({ isFollow }) => (isFollow ? 'red' : '#999999')};
+`;

--- a/src/pages/jobdetail/ApplyInformation.js
+++ b/src/pages/jobdetail/ApplyInformation.js
@@ -1,0 +1,275 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+
+const ApplyInformation = ({
+  setApply,
+  userFile,
+  setUserFile,
+  setSubmitModal,
+  detailList,
+}) => {
+  const [submitBtn, setSubmitBtn] = useState(true);
+
+  useEffect(() => {
+    fetch('http://10.58.2.136:8000/resumes/list', {
+      method: 'GET',
+      // headers: {
+      //   Authorization: localStorage.getItem('token'),
+      // },
+    })
+      .then(res => res.json())
+      .then(res => {
+        let copy = [...userFile];
+        copy.unshift({ isChecked: true, file: res.result });
+        setUserFile(copy);
+      });
+  }, []);
+
+  console.log('fileUpload', userFile);
+
+  const goToBack = () => {
+    setApply(true);
+  };
+
+  const uploadHandler = e => {
+    let copy = [...userFile];
+    copy.unshift({ isChecked: true, file: e.target.files[0] });
+    setUserFile(copy);
+
+    const formData = new FormData();
+    formData.append('resume', userFile[0].file);
+
+    fetch('http://10.58.2.136:8000/resumes/upload', {
+      method: 'POST',
+      // headers: {
+      //   Authorization: localStorage.getItem('token'),
+      // },
+      body: formData,
+    }).then(res => res.json());
+  };
+
+  const handleFileChecked = name => {
+    const newFileCheck = userFile.map(item => {
+      if (item.file.name === name) {
+        item.isChecked = !item.isChecked;
+      }
+      return item;
+    });
+    setUserFile(newFileCheck);
+    let result = userFile.some(item => item.isChecked === false);
+    setSubmitBtn(!result);
+  };
+
+  const handleSubmitBtn = () => {
+    setSubmitModal(true);
+  };
+
+  return (
+    <InformationArea>
+      <InfoTitle>
+        <div />
+        <div>지원하기</div>
+        <ApplyBack onClick={goToBack}>뒤로</ApplyBack>
+      </InfoTitle>
+      <InfoInputBox>
+        <ApplyInfoTitle>지원 정보</ApplyInfoTitle>
+        <ApplyInfoInput>
+          <FileBox>이름</FileBox>
+          <ApplyInput defaultValue={detailList.user_info?.name} />
+        </ApplyInfoInput>
+        <ApplyInfoInput>
+          <FileBox>이메일</FileBox>
+          <ApplyInput defaultValue={detailList.user_info?.email} />
+        </ApplyInfoInput>
+        <ApplyInfoInput>
+          <FileBox>휴대폰 번호</FileBox>
+          <ApplyInput />
+        </ApplyInfoInput>
+        <ApplyInfoInput>
+          <FileBox>추천인</FileBox>
+          <ApplyInput placeholder="선택사항" />
+        </ApplyInfoInput>
+        <ApplyInfoTitle>첨부파일</ApplyInfoTitle>
+        {userFile &&
+          userFile.map((files, i) => {
+            return (
+              <AttachFile
+                key={i}
+                onChange={() => handleFileChecked(files.file.name)}
+                isCheck={files.isChecked}
+              >
+                <input type="checkbox" />
+                <div>
+                  <FileName>{files.file.name}</FileName>
+                  <FileDate>2022.06.16 첨부파일</FileDate>
+                </div>
+              </AttachFile>
+            );
+          })}
+
+        <Upload>
+          <UploadInput
+            display="none"
+            type="file"
+            id="avatar"
+            name="avatar"
+            accept=".pdf"
+            onChange={e => uploadHandler(e)}
+          />
+          <label htmlFor="avatar">첨부파일</label>
+        </Upload>
+
+        <UploadFile bg="white" fontColor="#666666">
+          새 이력서 작성
+        </UploadFile>
+        <Postscript>
+          원티드 이력서로 지원하면 최종 합격률이 40% 높아집니다.
+        </Postscript>
+      </InfoInputBox>
+      <SubmitResume>
+        <UploadFile
+          bg="#3366ff"
+          fontColor="white"
+          disabled={submitBtn}
+          onClick={handleSubmitBtn}
+        >
+          제출하기
+        </UploadFile>
+      </SubmitResume>
+    </InformationArea>
+  );
+};
+
+export default ApplyInformation;
+
+const InformationArea = styled.div`
+  width: 100%;
+  border: 1px solid #e1e2e3;
+  border-radius: 4px;
+  position: relative;
+`;
+
+const InfoTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid #e1e2e3;
+  font-weight: 600;
+`;
+
+const ApplyBack = styled.div`
+  color: #999999;
+  cursor: pointer;
+`;
+
+const InfoInputBox = styled.div`
+  width: 100%;
+  height: 600px;
+  border: 1px solid #e1e2e3;
+  overflow-y: auto;
+  overflow-x: hidden;
+`;
+
+const ApplyInfoTitle = styled.div`
+  margin-top: 30px;
+  padding: 8px 20px;
+  border-left: 2px solid #258bf7;
+  font-weight: 600;
+`;
+
+const ApplyInfoInput = styled.div`
+  display: flex;
+  margin: 20px 20px 0 20px;
+  border-bottom: 1px solid #e1e2e3;
+  font-weight: 600;
+`;
+
+const ApplyInput = styled.input`
+  border: none;
+  padding-left: 20px;
+  margin-bottom: 15px;
+  font-size: 17px;
+  font-weight: 600;
+`;
+
+const FileBox = styled.div`
+  width: 90px;
+  margin-top: 5px;
+  color: #333333;
+`;
+
+const AttachFile = styled.div`
+  display: flex;
+  width: 350px;
+  margin: 20px 20px;
+  padding: 20px;
+  border: 1px solid #ececec;
+  border-radius: 6px;
+  border-color: ${({ isCheck }) => (isCheck ? '#ececec' : '#3366FF')};
+
+  input {
+    width: 20px;
+    height: 20px;
+    margin-right: 20px;
+  }
+`;
+const FileName = styled.div`
+  font-weight: 600;
+`;
+
+const FileDate = styled.div`
+  margin-top: 3px;
+  font-size: 13px;
+`;
+
+const Postscript = styled.div`
+  margin: 20px;
+  margin-bottom: 40px;
+  font-size: 14px;
+  color: #666666;
+`;
+
+const Upload = styled.form`
+  display: flex;
+  justify-content: center;
+  width: 350px;
+  margin: 10px 20px 0 20px;
+  padding: 15px 0;
+  border: 1px solid #ececec;
+  border-radius: 50px;
+  color: #666666;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const UploadInput = styled.input`
+  display: ${props => props.display};
+`;
+
+const UploadFile = styled.button`
+  width: 350px;
+  margin: 10px 20px 0 20px;
+  padding: 15px 0;
+  border: 1px solid #ececec;
+  border-radius: 50px;
+  background-color: ${props => props.bg};
+  color: ${props => props.fontColor};
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    background-color: #f2f4f7;
+    color: #666666;
+    cursor: default;
+  }
+`;
+
+const SubmitResume = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  border: 1px solid #e1e2e3;
+`;

--- a/src/pages/jobdetail/CompanySlide.js
+++ b/src/pages/jobdetail/CompanySlide.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import Slider from 'react-slick';
+import NextArrow from './NextArrow';
+import PrevArrow from './PrevArrow';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+import 'react-multi-carousel/lib/styles.css';
+
+const settings = {
+  dots: true,
+  infinite: true,
+  speed: 500,
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  nextArrow: <NextArrow />,
+  prevArrow: <PrevArrow />,
+};
+
+const CompanySlide = ({ detailList }) => {
+  return (
+    <Slider {...settings}>
+      <SlideImg>
+        <img src={detailList.job_detail?.company_images[0]} alt="companyImg1" />
+      </SlideImg>
+
+      <SlideImg>
+        <img src={detailList.job_detail?.company_images[1]} alt="companyImg2" />
+      </SlideImg>
+
+      <SlideImg>
+        <img
+          src={detailList.job_detail?.company_images?.[2]}
+          alt="companyImg3"
+        />
+      </SlideImg>
+    </Slider>
+  );
+};
+
+export default CompanySlide;
+
+const SlideImg = styled.div`
+  width: 100%;
+  height: 450px;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`;

--- a/src/pages/jobdetail/DetailMap.js
+++ b/src/pages/jobdetail/DetailMap.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import NaverMaps from './NaverMaps';
+
+const DetailMap = ({ detailList }) => {
+  return (
+    <MapArea>
+      <MapDescription>
+        <Title>마감일</Title>
+        <span>{detailList.job_detail?.job_deadline}</span>
+      </MapDescription>
+      <MapDescription>
+        <Title>근무지역</Title>
+        <span>{detailList.job_detail?.company_address}</span>
+      </MapDescription>
+      <NaverMaps detailList={detailList} />
+    </MapArea>
+  );
+};
+
+export default DetailMap;
+
+const MapArea = styled.div`
+  margin-top: 40px;
+`;
+
+const MapDescription = styled.div`
+  display: flex;
+  margin-top: 10px;
+
+  span {
+    margin-right: 20px;
+    font-weight: 600;
+  }
+`;
+
+const Title = styled.span`
+  width: 70px;
+  color: #999;
+  font-weight: 700;
+`;

--- a/src/pages/jobdetail/JobDetail.js
+++ b/src/pages/jobdetail/JobDetail.js
@@ -1,3 +1,259 @@
-const JobDetail = () => {};
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { RiErrorWarningLine } from '@react-icons/all-files/ri/RiErrorWarningLine';
+import styled from 'styled-components';
+import JobDetailDescription from './JobDetailDescription';
+import DetailMap from './DetailMap';
+import Apply from './Apply';
+import ApplyInformation from './ApplyInformation';
+import SubmitModal from './SubmitModal';
+import CompanySlide from './CompanySlide';
+
+const JobDetail = () => {
+  const [apply, setApply] = useState(true);
+  const [detailList, setDetailList] = useState({});
+  const [follow, setFollow] = useState({});
+  const [userFile, setUserFile] = useState([]);
+  const [submitModal, setSubmitModal] = useState(false);
+  const { company_id } = useParams();
+
+  useEffect(() => {
+    fetch(`http://10.58.3.196:8000/${company_id}/job`, {
+      method: 'GET',
+      headers: {
+        Authorization: localStorage.getItem('token'),
+      },
+    })
+      .then(res => res.json())
+      .then(res => {
+        setDetailList(res);
+      });
+
+    fetch(`http://10.58.3.196:8000/${company_id}/followedjob`, {
+      method: 'POST',
+      headers: {
+        Authorization: localStorage.getItem('token'),
+      },
+      body: follow,
+    })
+      .then(res => res.json())
+      .then(data => {
+        setFollow(data);
+      });
+  }, [setFollow]);
+
+  const likeBtn = () => {
+    fetch('/data/followData.json', {
+      method: 'POST',
+    })
+      .then(res => res.json())
+      .then(data => {
+        setFollow(data);
+      });
+  };
+
+  return (
+    <div>
+      {submitModal ? <SubmitModal setSubmitModal={setSubmitModal} /> : null}
+      <Wrapper>
+        <LeftWrapper>
+          <CompanySlide detailList={detailList} />
+          <LeftTitle>{detailList.job_detail?.job_name}</LeftTitle>
+          <CompanyDescription>
+            <CompanyTitle>{detailList.job_detail?.company_name}</CompanyTitle>
+            <CompanyResponse>응답룰 매우 높음</CompanyResponse>
+            <span>|</span>
+            <p>{detailList.job_detail?.company_location}</p>
+          </CompanyDescription>
+          <HashTagArea>
+            <span>#스타트업</span>
+            <span>#재택근무</span>
+            <span>#IT,컨텐츠</span>
+          </HashTagArea>
+          <JobDetailDescription detailList={detailList} />
+          <SkillStackArea>
+            <span>Git</span>
+            <span>Github</span>
+            <span>Javascript</span>
+            <span>Python</span>
+          </SkillStackArea>
+          <UnderBar />
+          <DetailMap detailList={detailList} />
+          <FollowBox>
+            <FollowCompany>
+              <img src={detailList.job_detail?.company_logo} alt="" />
+              <FollowCompanyTitle>
+                <CompanyField>
+                  {detailList.job_detail?.company_name}
+                </CompanyField>
+                <div className="CompanyField">IT,컨텐츠</div>
+              </FollowCompanyTitle>
+            </FollowCompany>
+            <FollowBtn onClick={likeBtn}>좋아요</FollowBtn>
+          </FollowBox>
+          <WarnBox>
+            <RiErrorWarningLine className="warnIcon" />
+            <WarnSentence>
+              본 채용정보는 원티드랩의 동의없이 무단전재, 재배포, 재가공할 수
+              없으며, 구직활동 이외의 용도로 사용할 수 없습니다.
+            </WarnSentence>
+          </WarnBox>
+        </LeftWrapper>
+        <RightWrapper>
+          {apply ? (
+            <Apply
+              setApply={setApply}
+              detailList={detailList}
+              setDetailList={setDetailList}
+              follow={follow}
+              likeBtn={likeBtn}
+            />
+          ) : (
+            <ApplyInformation
+              setApply={setApply}
+              userFile={userFile}
+              follow={follow}
+              setUserFile={setUserFile}
+              setSubmitModal={setSubmitModal}
+              detailList={detailList}
+              likeBtn={likeBtn}
+            />
+          )}
+        </RightWrapper>
+      </Wrapper>
+    </div>
+  );
+};
 
 export default JobDetail;
+
+const Wrapper = styled.div`
+  display: flex;
+  position: relative;
+  width: 70rem;
+  margin: auto;
+  padding-top: 4%;
+  margin-bottom: 10%;
+`;
+
+const LeftWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 60%;
+`;
+
+const LeftTitle = styled.div`
+  margin-top: 20px;
+  font-size: 22px;
+  font-weight: 700;
+`;
+
+const CompanyDescription = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+
+  span {
+    margin-right: 10px;
+    color: lightgrey;
+  }
+`;
+
+const CompanyTitle = styled.div`
+  margin-right: 10px;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const CompanyResponse = styled.div`
+  border: 1px solid green;
+  margin-right: 10px;
+  padding: 4px;
+  font-size: 12px;
+  color: green;
+`;
+
+const HashTagArea = styled.div`
+  display: flex;
+
+  span {
+    padding: 8px 10px;
+    margin: 10px 10px 10px 0;
+    border-radius: 10px;
+    background: #f2f5f8;
+  }
+`;
+
+const SkillStackArea = styled.div`
+  display: flex;
+  margin-top: 10px;
+
+  span {
+    padding: 8px 10px;
+    margin: 10px 5px 0 0;
+    border-radius: 15px;
+    background: #e4f4ec;
+  }
+`;
+
+const UnderBar = styled.div`
+  margin-top: 60px;
+  border: 1px solid #eee;
+`;
+
+const FollowBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 20px;
+  margin-top: 40px;
+  border: 1px solid #e1e2e3;
+`;
+
+const FollowCompany = styled.div`
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+
+  img {
+    width: 70px;
+  }
+`;
+
+const FollowCompanyTitle = styled.div`
+  margin-left: 10px;
+`;
+
+const CompanyField = styled.div`
+  color: #999;
+`;
+
+const FollowBtn = styled.button`
+  padding: 10px 20px;
+  border: 1px solid #e1e2e3;
+  border-radius: 50px;
+  background: white;
+  color: #36f;
+  cursor: pointer;
+`;
+
+const WarnBox = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 20px;
+  margin-top: 10px;
+  font-size: 30px;
+  background: #f3f5f8;
+`;
+
+const WarnSentence = styled.div`
+  margin: 4px;
+  font-size: 12px;
+`;
+
+const RightWrapper = styled.div`
+  position: fixed;
+  width: 25rem;
+  right: 22%;
+`;

--- a/src/pages/jobdetail/JobDetailDescription.js
+++ b/src/pages/jobdetail/JobDetailDescription.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const JobDetailDescription = ({ detailList }) => {
+  const codes = detailList.job_detail?.job_content;
+
+  return (
+    <DescriptionWrapper>
+      <div dangerouslySetInnerHTML={{ __html: codes }} />
+      <DescriptionTitle>기술스택 ・ 툴</DescriptionTitle>
+    </DescriptionWrapper>
+  );
+};
+
+export default JobDetailDescription;
+
+const DescriptionWrapper = styled.div`
+  margin-top: 10px;
+  line-height: 1.5em;
+  color: gray;
+`;
+
+const DescriptionTitle = styled.div`
+  font-size: 20px;
+  font-weight: 600;
+`;

--- a/src/pages/jobdetail/NaverMaps.js
+++ b/src/pages/jobdetail/NaverMaps.js
@@ -1,0 +1,31 @@
+import { RenderAfterNavermapsLoaded, NaverMap, Marker } from 'react-naver-maps'; // 패키지 불러오기
+
+const NaverMaps = ({ detailList }) => {
+  return (
+    <RenderAfterNavermapsLoaded
+      ncpClientId="4y7dwiag1m"
+      error={<p>Maps Load Error</p>}
+      loading={<p>Maps Loading...</p>}
+    >
+      <NaverMap
+        id="react-naver-maps-introduction"
+        style={{ width: '100%', height: '260px', marginTop: '30px' }}
+        defaultCenter={{
+          lat: detailList.job_detail?.company_latitude,
+          lng: detailList.job_detail?.company_longitude,
+        }}
+        defaultZoom={16}
+      >
+        <Marker
+          position={{
+            lat: detailList.job_detail?.company_latitude,
+            lng: detailList.job_detail?.company_longitude,
+          }}
+          animation={1}
+        />
+      </NaverMap>
+    </RenderAfterNavermapsLoaded>
+  );
+};
+
+export default NaverMaps;

--- a/src/pages/jobdetail/NextArrow.js
+++ b/src/pages/jobdetail/NextArrow.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { MdKeyboardArrowRight } from '@react-icons/all-files/md/MdKeyboardArrowRight';
+
+const NextArrow = props => {
+  const { className, style, onClick } = props;
+  return (
+    <MdKeyboardArrowRight
+      className={className}
+      style={{
+        ...style,
+        display: 'block',
+        color: 'black',
+        background: 'white',
+        borderRadius: '50%',
+      }}
+      onClick={onClick}
+    />
+  );
+};
+
+export default NextArrow;

--- a/src/pages/jobdetail/PrevArrow.js
+++ b/src/pages/jobdetail/PrevArrow.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { MdKeyboardArrowLeft } from '@react-icons/all-files/md/MdKeyboardArrowLeft';
+
+export const PrevArrow = props => {
+  const { className, style, onClick } = props;
+  return (
+    <MdKeyboardArrowLeft
+      className={className}
+      style={{
+        ...style,
+        display: 'block',
+        color: 'black',
+        background: 'white',
+        borderRadius: '50%',
+      }}
+      onClick={onClick}
+    />
+  );
+};
+
+export default PrevArrow;

--- a/src/pages/jobdetail/SubmitModal.js
+++ b/src/pages/jobdetail/SubmitModal.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import { GrFormClose } from '@react-icons/all-files/gr/GrFormClose';
+
+const SubmitModal = ({ setSubmitModal }) => {
+  const modalClose = () => {
+    setSubmitModal(false);
+  };
+  return (
+    <Modal>
+      <AlertPage>
+        <CloseIcon>
+          <GrFormClose onClick={modalClose} />
+        </CloseIcon>
+        <AlertTitle>지원이 완료되었습니다.</AlertTitle>
+        <AlertDescription>
+          대상자분들은 지원하신 이력서를 바탕으로 매치업 프로필을
+          <br />
+          자동 생성해 드릴 예정입니다. 프로필이 생성되면,
+          <br />
+          기업으로부터 매치업을 통한 "면접 제안"을 받으실 수 있습니다.
+        </AlertDescription>
+        <AlertBtn onClick={modalClose}> 확인 </AlertBtn>
+      </AlertPage>
+    </Modal>
+  );
+};
+
+export default SubmitModal;
+
+const Modal = styled.div`
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  background: rgba(76, 76, 76, 0.5);
+  z-index: 99999;
+`;
+
+const AlertPage = styled.div`
+  position: relative;
+  text-align: center;
+  width: 500px;
+  padding: 20px;
+  border-radius: 5px;
+  background: white;
+`;
+
+const CloseIcon = styled.div`
+  font-size: 30px;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  cursor: pointer;
+`;
+
+const AlertTitle = styled.div`
+  margin-top: 40px;
+  font-size: 23px;
+  font-weight: 700;
+`;
+
+const AlertDescription = styled.div`
+  margin-top: 40px;
+  line-height: 30px;
+  font-size: 15px;
+  color: gray;
+`;
+
+const AlertBtn = styled.button`
+  margin-top: 40px;
+  width: 100%;
+  padding: 20px;
+  border: none;
+  border-radius: 50px;
+  color: white;
+  font-size: 18px;
+  background-color: #3366ff;
+  cursor: pointer;
+`;

--- a/src/pages/likePage/LikePage.js
+++ b/src/pages/likePage/LikePage.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+const LikePage = () => {
+  const [likeList, setLikeList] = useState({});
+
+  useEffect(() => {
+    fetch('http://10.58.3.196:8000/job/followedjob', {
+      method: 'GET',
+      headers: {
+        Authorization: localStorage.getItem('token'),
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setLikeList(data.results);
+      });
+  }, []);
+
+  return (
+    <LikeContainer>
+      <ContainerCenter>
+        <PageTitle>좋아요</PageTitle>
+        <LikeCompany>
+          <LikeCompanyBox>
+            <LikeCompanyImg alt="Company img" src={likeList[0]?.image} />
+            <CompanyDescription>{likeList[0]?.position}</CompanyDescription>
+            <CompanyTitle>{likeList[0]?.company_name}</CompanyTitle>
+            <CompanyLocal>{likeList[0]?.location}</CompanyLocal>
+          </LikeCompanyBox>
+        </LikeCompany>
+      </ContainerCenter>
+    </LikeContainer>
+  );
+};
+
+export default LikePage;
+
+const LikeContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100vh;
+  background-color: #f8f8fa;
+`;
+
+const ContainerCenter = styled.div`
+  width: 75rem;
+  padding: 100px 40px;
+`;
+
+const PageTitle = styled.div`
+  font-size: 20px;
+  font-weight: 700;
+`;
+
+const LikeCompany = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const LikeCompanyBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+  margin: 20px 30px 0 0;
+`;
+
+const LikeCompanyImg = styled.img`
+  width: 250px;
+  height: 180px;
+`;
+
+const CompanyDescription = styled.div`
+  margin-top: 10px;
+  line-height: 20px;
+  font-size: 17px;
+  font-weight: 600;
+`;
+
+const CompanyTitle = styled.div`
+  margin-top: 10px;
+  font-weight: 600;
+`;
+
+const CompanyLocal = styled.div`
+  margin-top: 10px;
+  font-size: 14px;
+  color: #999999;
+`;


### PR DESCRIPTION
jobDetail page layout

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- styled component를 이용하여 레이아웃을 구성 할 수 있다.
- 지원하기 버튼을 누르면 지원서작성 페이지로 갈 수 있다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. styled component를 이용하여 레이아웃을 구성 할 수 있다.
- styled component를 GlobalStyle와 theme 파일로 초기화 및 커스텀 하기
- styled component를 사용하여 레이아웃 구성
- 비슷한 style의 레이아웃은 반복 작성하지 않고 styled component의 특성을 이용해 props를 이용해 style 변경

2. 지원하기 버튼을 누르면 지원서작성 페이지로 갈 수 있다.
- 버튼에 함수를 주어 누르면 true,false값이 바뀌게 하기
- 값이 true와 false일 때 각각 다른 페이지가 나오게 만들기

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 처음으로 사용해 보는 styled component로 처음엔 헥갈렸지만 사용하면서 이런 방법도 잇구나 하는 생각이 들었다
- styled component의 특성 중 props를 사용 해 보고 다양한 변화를 경험 해 볼 수 있었다.

<br />

## :: 기타 질문 및 특이 사항

